### PR TITLE
Removed custom test pattern matcher

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [nosetests]
-match=^test
 where=meniscus
 nocapture=1
 cover-package=meniscus


### PR DESCRIPTION
The test pattern matcher in setup.cfg was preventing nose from finding tests.
