### PR TITLE
moved initialization of db_handler from tenant's app.py into datastor_init.py under the api directory to allow other api's that need a db_handler to simply import that method.  Also cleaned up "import * " from api.tenant.resources.py

### DIFF
--- a/meniscus/api/datastore_init.py
+++ b/meniscus/api/datastore_init.py
@@ -1,0 +1,13 @@
+from meniscus.data import adapters
+from meniscus.data.handler import datasource_handler
+from meniscus.config import init_config, get_config
+
+
+init_config()
+conf = get_config()
+_handler = datasource_handler(conf)
+_handler.connect()
+
+
+def db_handler():
+    return _handler

--- a/meniscus/api/tenant/app.py
+++ b/meniscus/api/tenant/app.py
@@ -1,19 +1,10 @@
 import falcon
 
-from meniscus.api.tenant.resources import *
-from meniscus.data import adapters
-from meniscus.data.handler import datasource_handler
-from meniscus.config import init_config, get_config
+from meniscus.api.tenant.resources import VersionResource, \
+    TenantResource, UserResource, HostProfilesResource, HostProfileResource, \
+    EventProducersResource, EventProducerResource, HostsResource, HostResource
 
-
-init_config()
-conf = get_config()
-_handler = datasource_handler(conf)
-_handler.connect()
-
-
-def db_handler():
-    return _handler
+from meniscus.api.datastore_init import db_handler
 
 
 # Resources


### PR DESCRIPTION
...Also corrected import \* in tenant/resources.py
