### PR TITLE
Don't use mutable types for default parameters

### DIFF
--- a/meniscus/data/adapters/mongodb.py
+++ b/meniscus/data/adapters/mongodb.py
@@ -79,19 +79,27 @@ class MongoDatasourceHandler(DatasourceHandler):
         return self.database['counters'].find_and_modify(
             {'name': sequence_name}, {'$inc': {'seq': 1}})['seq']
 
-    def find(self, object_name, query_filter=dict()):
+    def find(self, object_name, query_filter=None):
+        if query_filter is None:
+            query_filter = dict()
         self._check_connection()
         return self.database[object_name].find(query_filter)
 
-    def find_one(self, object_name, query_filter=dict()):
+    def find_one(self, object_name, query_filter=None):
+        if query_filter is None:
+            query_filter = dict()
         self._check_connection()
         return self.database[object_name].find_one(query_filter)
 
-    def put(self, object_name, document=dict()):
+    def put(self, object_name, document=None):
+        if document is None:
+            document = dict()
         self._check_connection()
         self.database[object_name].insert(document)
 
-    def update(self, object_name, document=dict()):
+    def update(self, object_name, document=None):
+        if document is None:
+            document = dict()
         self._check_connection()
 
         if '_id' not in document:

--- a/meniscus/data/handler.py
+++ b/meniscus/data/handler.py
@@ -70,19 +70,29 @@ class DatasourceHandler():
     def next_sequence(self, sequence_name):
         raise NotImplementedError
 
-    def find(self, object_name, query_filter=dict()):
+    def find(self, object_name, query_filter=None):
+        if query_filter is None:
+            query_filter = dict()
         raise NotImplementedError
 
-    def find_one(self, object_name, query_filter=dict()):
+    def find_one(self, object_name, query_filter=None):
+        if query_filter is None:
+            query_filter = dict()
         raise NotImplementedError
 
-    def put(self, object_name, document=dict()):
+    def put(self, object_name, document=None):
+        if document is None:
+            document = dict()
         raise NotImplementedError
 
-    def update(self, object_name, document=dict()):
+    def update(self, object_name, document=None):
+        if document is None:
+            document = dict()
         raise NotImplementedError
 
-    def delete(self, object_name, query_filter=dict(), limit_one=False):
+    def delete(self, object_name, query_filter=None, limit_one=False):
+        if query_filter is None:
+            query_filter = dict()
         raise NotImplementedError
 
 

--- a/meniscus/data/model/tenant.py
+++ b/meniscus/data/model/tenant.py
@@ -33,8 +33,8 @@ Host profiles are reusable collections of event producers with an
 associated, unique name for lookup.
 """
 
-    def __init__(self, _id, name, event_producer_ids=list()):
-        if not event_producer_ids:
+    def __init__(self, _id, name, event_producer_ids=None):
+        if event_producer_ids is None:
             event_producer_ids = []
 
         self._id = _id

--- a/meniscus/ext/plugin.py
+++ b/meniscus/ext/plugin.py
@@ -26,7 +26,9 @@ class PluginError(ImportError):
 
 class PluginFinder():
 
-    def __init__(self, paths=list()):
+    def __init__(self, paths=None):
+        if paths is None:
+            paths = list()
         self.plugin_paths = paths
 
     def add_path(self, new_path):

--- a/meniscus/personas/coordinator/app.py
+++ b/meniscus/personas/coordinator/app.py
@@ -16,7 +16,7 @@ from meniscus.api.version.resources import VersionResource
 from meniscus.api.datastore_init import db_handler
 
 
-def start_up(cfg=dict()):
+def start_up():
     #Common Resource(s)
     versions = VersionResource()
 

--- a/meniscus/personas/worker/correlation/app.py
+++ b/meniscus/personas/worker/correlation/app.py
@@ -6,7 +6,7 @@ from meniscus.api.correlation.resources import PublishMessageResource
 from meniscus.api.version.resources import VersionResource
 
 
-def start_up(cfg=dict()):
+def start_up():
     cache = NativeProxy()
     versions = VersionResource()
     publish_message = PublishMessageResource(cache)

--- a/meniscus/personas/worker/normalization/app.py
+++ b/meniscus/personas/worker/normalization/app.py
@@ -3,7 +3,7 @@ from meniscus.personas.worker.register_online import RegisterWorkerOnline
 from meniscus.api.version.resources import VersionResource
 
 
-def start_up(cfg=dict()):
+def start_up():
 
     versions = VersionResource()
     # Routing

--- a/meniscus/personas/worker/pairing/app.py
+++ b/meniscus/personas/worker/pairing/app.py
@@ -4,7 +4,7 @@ from meniscus.api.version.resources import VersionResource
 from meniscus.api.pairing.resources import PairingConfigurationResource
 
 
-def start_up(cfg=dict()):
+def start_up():
     # Resources
     versions = VersionResource()
     configuration = PairingConfigurationResource()

--- a/meniscus/personas/worker/storage/app.py
+++ b/meniscus/personas/worker/storage/app.py
@@ -3,7 +3,7 @@ from meniscus.personas.worker.register_online import RegisterWorkerOnline
 from meniscus.api.version.resources import VersionResource
 
 
-def start_up(cfg=dict()):
+def start_up():
 
     versions = VersionResource()
     # Routing


### PR DESCRIPTION
Using mutable types for default parameters can lead to buggy code.

Don't do this:

```
def foo(x=dict()):
    pass
```

Do this:

```
def foo(x=None):
    if x is None:
        x = dict()
    pass
```

For more info see Default Parameters: http://docs.python.org/2/reference/compound_stmts.html#function-definitions
