### PR TITLE
Return 400 when provided negative load averages

### DIFF
--- a/etc/meniscus/schemas/worker_status.json
+++ b/etc/meniscus/schemas/worker_status.json
@@ -70,13 +70,16 @@
 
             "properties":{
                 "1": {
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 0
                 },
                 "5": {
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 0
                 },
                 "15": {
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 0
                 }
             }
         },

--- a/meniscus/tests/api/status/resources_test.py
+++ b/meniscus/tests/api/status/resources_test.py
@@ -77,6 +77,22 @@ class WhenTestingWorkerUpdateOnPut(testing.TestBase):
             body=jsonutils.dumps(self.bad_worker_status))
         self.assertEqual(falcon.HTTP_400, self.srmock.status)
 
+    def test_when_load_average_is_negative_then_should_return_http_400(self):
+        self.db_handler.find_one.return_value = self.worker_dict
+        system_info = SystemInfo()
+        system_info.load_average = {"1": -2, "15": -2, "5": -2}
+        self.simulate_request(
+            self.test_route,
+            method='PUT',
+            headers={'content-type':'application/json'},
+            body=jsonutils.dumps({
+                'worker_status': {
+                    'system_info': system_info.format(),
+                    'status': self.status
+                }
+            }))
+        self.assertEqual(falcon.HTTP_400, self.srmock.status)
+
     def test_returns_200_worker_status(self):
         self.db_handler.find_one.return_value = self.worker_dict
         self.simulate_request(


### PR DESCRIPTION
Modified the JSON schema for worker statuses to include a minimum of
zero for each load average. Added a unit test for regression.
