### PR TITLE
There shouldn't be two daemon scripts (init.d and upstart). Since we are...

### DIFF
--- a/pkg/layout/etc/init/meniscus
+++ b/pkg/layout/etc/init/meniscus
@@ -1,6 +1,0 @@
-description "Project Meniscus API node daemon"
-author "John Hopper"
-start on (local-filesystems and net-device-up)
-stop on runlevel [06]
-respawn
-exec /usr/share/meniscus/bin/uwsgi --ini /etc/meniscus/uwsgi.ini


### PR DESCRIPTION
... currently using the init.d way the upstart menicus.conf needs to be removed to avoid possible duplication of dual meniscus services starting.
